### PR TITLE
feat: Inventory POS platform (auth session cookies + Cycle 1)

### DIFF
--- a/InventoryX.Application/Commands/RequestHandlers/Auth/LoginCommandHandler.cs
+++ b/InventoryX.Application/Commands/RequestHandlers/Auth/LoginCommandHandler.cs
@@ -46,10 +46,15 @@ namespace InventoryX.Application.Commands.RequestHandlers.Auth
     {
         public async Task<LoginResult> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
         {
+            if (string.IsNullOrWhiteSpace(request.RefreshToken))
+                throw new CustomException("Invalid or expired refresh token.", 401);
+
             var userId = tokenService.ValidateRefreshToken(request.RefreshToken)
                 ?? throw new CustomException("Invalid or expired refresh token.", 401);
             var user = await userManager.FindByIdAsync(userId)
                 ?? throw new CustomException("Invalid refresh token.", 401);
+
+            tokenService.RevokeRefreshToken(request.RefreshToken);
 
             var role = user.RoleId is null
                 ? null

--- a/InventoryX.Application/Commands/Requests/Auth/LoginCommand.cs
+++ b/InventoryX.Application/Commands/Requests/Auth/LoginCommand.cs
@@ -18,7 +18,10 @@ namespace InventoryX.Application.Commands.Requests.Auth
 
     public class RefreshTokenCommand : IRequest<LoginResult>
     {
-        public required string RefreshToken { get; init; }
+        /// <summary>
+        /// Optional when the httpOnly <c>inventoryx_refresh</c> cookie is present (silent SPA restore).
+        /// </summary>
+        public string? RefreshToken { get; init; }
     }
 
     public record TwoFactorEnrollResult(string SharedKey, string AuthenticatorUri);

--- a/InventoryX.Application/Services/IServices/ITokenService.cs
+++ b/InventoryX.Application/Services/IServices/ITokenService.cs
@@ -19,5 +19,8 @@ namespace InventoryX.Application.Services.IServices
 
         /// <summary>Validates a refresh token and returns the user id it was issued to, or null.</summary>
         string? ValidateRefreshToken(string refreshToken);
+
+        /// <summary>Invalidates a refresh token so it cannot be reused after rotation or sign-out.</summary>
+        void RevokeRefreshToken(string refreshToken);
     }
 }

--- a/InventoryX.Infrastructure/Services/JwtTokenService.cs
+++ b/InventoryX.Infrastructure/Services/JwtTokenService.cs
@@ -44,6 +44,9 @@ namespace InventoryX.Infrastructure.Services
         public string? ValidateRefreshToken(string refreshToken) =>
             refreshTokenStore.TryGetValue($"refresh:{refreshToken}", out string? userId) ? userId : null;
 
+        public void RevokeRefreshToken(string refreshToken) =>
+            refreshTokenStore.Remove($"refresh:{refreshToken}");
+
         private static List<Claim> BuildClaims(User user, Role? role)
         {
             var claims = new List<Claim>

--- a/InventoryX.Presentation/Authentication/AuthSessionCookies.cs
+++ b/InventoryX.Presentation/Authentication/AuthSessionCookies.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Options;
+using InventoryX.Application.Options;
+
+namespace InventoryX.Presentation.Authentication;
+
+/// <summary>
+/// SPA session durability: httpOnly refresh cookie for silent restore, plus a readable
+/// <c>inventoryx_session</c> marker so anonymous cold loads never hit /auth/refresh.
+/// </summary>
+public static class AuthSessionCookies
+{
+    public const string RefreshTokenCookieName = "inventoryx_refresh";
+    public const string SessionMarkerCookieName = "inventoryx_session";
+    public const string RefreshCookiePath = "/api/v1/auth";
+
+    public static void Set(HttpResponse response, string refreshToken, TimeSpan lifetime)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(refreshToken);
+        if (lifetime <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(lifetime));
+
+        var expires = DateTimeOffset.UtcNow.Add(lifetime);
+        response.Cookies.Append(RefreshTokenCookieName, refreshToken, new CookieOptions
+        {
+            HttpOnly = true,
+            Secure = true,
+            SameSite = SameSiteMode.Lax,
+            Path = RefreshCookiePath,
+            IsEssential = true,
+            Expires = expires,
+        });
+        response.Cookies.Append(SessionMarkerCookieName, "1", new CookieOptions
+        {
+            HttpOnly = false,
+            Secure = true,
+            SameSite = SameSiteMode.Lax,
+            Path = "/",
+            IsEssential = true,
+            Expires = expires,
+        });
+    }
+
+    public static void Set(HttpResponse response, string refreshToken, IOptions<JwtOptions> jwtOptions) =>
+        Set(response, refreshToken, TimeSpan.FromDays(Math.Max(1, jwtOptions.Value.RefreshTokenDays)));
+
+    public static void Clear(HttpResponse response)
+    {
+        response.Cookies.Delete(RefreshTokenCookieName, new CookieOptions
+        {
+            Secure = true,
+            SameSite = SameSiteMode.Lax,
+            Path = RefreshCookiePath,
+        });
+        response.Cookies.Delete(SessionMarkerCookieName, new CookieOptions
+        {
+            Secure = true,
+            SameSite = SameSiteMode.Lax,
+            Path = "/",
+        });
+    }
+
+    public static string? ReadRefreshToken(HttpRequest request) =>
+        request.Cookies.TryGetValue(RefreshTokenCookieName, out var value) && !string.IsNullOrWhiteSpace(value)
+            ? value
+            : null;
+}

--- a/InventoryX.Presentation/Authentication/GoogleOAuthHandler.cs
+++ b/InventoryX.Presentation/Authentication/GoogleOAuthHandler.cs
@@ -1,7 +1,13 @@
 using System.Security.Claims;
+using InventoryX.Application.Options;
+using InventoryX.Application.Services.IServices;
 using InventoryX.Domain.Models;
+using InventoryX.Infrastructure.Data;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.WebUtilities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace InventoryX.Presentation.Authentication;
 
@@ -11,86 +17,95 @@ public static class GoogleOAuthHandler
     {
         var userManager = context.HttpContext.RequestServices.GetRequiredService<UserManager<User>>();
         var signInManager = context.HttpContext.RequestServices.GetRequiredService<SignInManager<User>>();
+        var tokenService = context.HttpContext.RequestServices.GetRequiredService<ITokenService>();
+        var db = context.HttpContext.RequestServices.GetRequiredService<AppDbContext>();
+        var jwtOptions = context.HttpContext.RequestServices.GetRequiredService<IOptions<JwtOptions>>();
         var loggerFactory = context.HttpContext.RequestServices.GetRequiredService<ILoggerFactory>();
         var logger = loggerFactory.CreateLogger("InventoryX.Presentation.Authentication.GoogleOAuthHandler");
 
-        // Get the return URL from authentication properties
         var returnUrl = "/";
-        if (context.Properties?.Items != null && context.Properties.Items.TryGetValue("returnUrl", out var url))
+        if (context.Properties?.Items != null &&
+            context.Properties.Items.TryGetValue("returnUrl", out var url) &&
+            !string.IsNullOrWhiteSpace(url))
         {
-            returnUrl = url ?? "/";
+            returnUrl = url;
+        }
+        else if (!string.IsNullOrWhiteSpace(context.Properties?.RedirectUri))
+        {
+            returnUrl = context.Properties.RedirectUri;
         }
 
-        // Get user info from the ticket principal (already authenticated by Google)
         var email = context.Principal?.FindFirstValue(ClaimTypes.Email);
         var nameIdentifier = context.Principal?.FindFirstValue(ClaimTypes.NameIdentifier);
 
         logger.LogInformation("OAuth callback received for email: {Email}", email);
 
-        if (!string.IsNullOrEmpty(email) && !string.IsNullOrEmpty(nameIdentifier))
+        if (string.IsNullOrEmpty(email) || string.IsNullOrEmpty(nameIdentifier))
         {
-            // Check if user exists
-            var user = await userManager.FindByEmailAsync(email);
+            logger.LogWarning("OAuth callback missing email or nameIdentifier");
+            context.ReturnUri = returnUrl;
+            return;
+        }
 
-            if (user == null)
+        var user = await userManager.FindByEmailAsync(email);
+
+        if (user == null)
+        {
+            logger.LogInformation("Creating new user for email: {Email}", email);
+
+            user = new User();
+            await userManager.SetUserNameAsync(user, email);
+            await userManager.SetEmailAsync(user, email);
+
+            var name = context.Principal?.FindFirstValue(ClaimTypes.Name);
+            if (!string.IsNullOrEmpty(name))
+                user.Name = name;
+
+            var createResult = await userManager.CreateAsync(user);
+            if (!createResult.Succeeded)
             {
-                logger.LogInformation("Creating new user for email: {Email}", email);
-
-                // Create new user
-                user = new User();
-                await userManager.SetUserNameAsync(user, email);
-                await userManager.SetEmailAsync(user, email);
-
-                // Set name if available
-                var name = context.Principal?.FindFirstValue(ClaimTypes.Name);
-                if (!string.IsNullOrEmpty(name))
-                {
-                    user.Name = name;
-                }
-
-                var createResult = await userManager.CreateAsync(user);
-                if (createResult.Succeeded)
-                {
-                    // Confirm email for Google users
-                    var token = await userManager.GenerateEmailConfirmationTokenAsync(user);
-                    await userManager.ConfirmEmailAsync(user, token);
-
-                    // Add external login
-                    var loginInfo = new UserLoginInfo(context.Scheme.Name, nameIdentifier, context.Scheme.DisplayName);
-                    await userManager.AddLoginAsync(user, loginInfo);
-
-                    logger.LogInformation("User created successfully: {Email}", email);
-                }
-                else
-                {
-                    logger.LogError("Failed to create user: {Errors}", string.Join(", ", createResult.Errors.Select(e => e.Description)));
-                }
-            }
-            else
-            {
-                logger.LogInformation("User already exists: {Email}", email);
-
-                // User exists - check if external login is already linked
-                var existingLogins = await userManager.GetLoginsAsync(user);
-                if (!existingLogins.Any(l => l.LoginProvider == context.Scheme.Name && l.ProviderKey == nameIdentifier))
-                {
-                    // Link the external login to existing user
-                    var loginInfo = new UserLoginInfo(context.Scheme.Name, nameIdentifier, context.Scheme.DisplayName);
-                    await userManager.AddLoginAsync(user, loginInfo);
-                    logger.LogInformation("External login linked to existing user: {Email}", email);
-                }
+                logger.LogError("Failed to create user: {Errors}", string.Join(", ", createResult.Errors.Select(e => e.Description)));
+                context.ReturnUri = returnUrl;
+                return;
             }
 
-            // Sign in the user with cookie authentication
-            await signInManager.SignInAsync(user, isPersistent: true, authenticationMethod: IdentityConstants.ApplicationScheme);
-            logger.LogInformation("User signed in successfully: {Email}", email);
+            var confirmToken = await userManager.GenerateEmailConfirmationTokenAsync(user);
+            await userManager.ConfirmEmailAsync(user, confirmToken);
+
+            var loginInfo = new UserLoginInfo(context.Scheme.Name, nameIdentifier, context.Scheme.DisplayName);
+            await userManager.AddLoginAsync(user, loginInfo);
+
+            logger.LogInformation("User created successfully: {Email}", email);
         }
         else
         {
-            logger.LogWarning("OAuth callback missing email or nameIdentifier");
+            logger.LogInformation("User already exists: {Email}", email);
+
+            var existingLogins = await userManager.GetLoginsAsync(user);
+            if (!existingLogins.Any(l => l.LoginProvider == context.Scheme.Name && l.ProviderKey == nameIdentifier))
+            {
+                var loginInfo = new UserLoginInfo(context.Scheme.Name, nameIdentifier, context.Scheme.DisplayName);
+                await userManager.AddLoginAsync(user, loginInfo);
+                logger.LogInformation("External login linked to existing user: {Email}", email);
+            }
         }
 
-        // Redirect to frontend
-        context.ReturnUri = returnUrl;
+        await signInManager.SignInAsync(user, isPersistent: true, authenticationMethod: IdentityConstants.ApplicationScheme);
+
+        var role = user.RoleId is null
+            ? null
+            : await db.AppRoles.AsNoTracking().FirstOrDefaultAsync(r => r.Id == user.RoleId);
+        var tokens = tokenService.CreateTokenPair(user, role);
+        AuthSessionCookies.Set(context.HttpContext.Response, tokens.RefreshToken, jwtOptions);
+
+        var redirectParams = new Dictionary<string, string?>
+        {
+            ["accessToken"] = tokens.AccessToken,
+            ["refreshToken"] = tokens.RefreshToken,
+            ["accessTokenExpiresAt"] = tokens.AccessTokenExpiresAt.ToUniversalTime().ToString("O"),
+        };
+        context.ReturnUri = QueryHelpers.AddQueryString(returnUrl, redirectParams);
+
+        logger.LogInformation("User signed in successfully: {Email}", email);
     }
 }

--- a/InventoryX.Presentation/Configuration/DependencyInjection.cs
+++ b/InventoryX.Presentation/Configuration/DependencyInjection.cs
@@ -126,7 +126,11 @@ namespace InventoryX.Presentation.Configuration
             var jwtOptions = configuration.GetSection(JwtOptions.SectionName).Get<JwtOptions>() ?? new JwtOptions();
             var signingKey = jwtOptions.ResolveSigningKey();
 
-            var authBuilder = services.AddAuthentication()
+            var authBuilder = services.AddAuthentication(options =>
+                {
+                    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+                })
                 .AddJwtBearer(options =>
                 {
                     options.TokenValidationParameters = new TokenValidationParameters

--- a/InventoryX.Presentation/Controllers/v1/AuthController.cs
+++ b/InventoryX.Presentation/Controllers/v1/AuthController.cs
@@ -1,17 +1,22 @@
 using InventoryX.Application.Commands.Requests.Auth;
 using InventoryX.Application.Commands.Requests.Tenancy;
+using InventoryX.Application.Exceptions;
+using InventoryX.Application.Options;
+using InventoryX.Presentation.Authentication;
+using InventoryX.Presentation.Swagger;
 using MediatR;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using InventoryX.Presentation.Swagger;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Options;
 
 namespace InventoryX.Presentation.Controllers.v1;
 
 [Route("api/v1/auth")]
 [Authorize]
-public sealed class AuthController(ISender sender) : ApiControllerBase
+public sealed class AuthController(ISender sender, IOptions<JwtOptions> jwtOptions) : ApiControllerBase
 {
     [HttpPost("register")]
     [AllowAnonymous]
@@ -19,6 +24,7 @@ public sealed class AuthController(ISender sender) : ApiControllerBase
     public async Task<IActionResult> Register(RegisterTenantCommand command, CancellationToken cancellationToken)
     {
         var result = await sender.Send(command, cancellationToken);
+        AuthSessionCookies.Set(Response, result.RefreshToken, jwtOptions);
         return Created("/api/v1/tenant", result);
     }
 
@@ -27,15 +33,62 @@ public sealed class AuthController(ISender sender) : ApiControllerBase
     public async Task<IActionResult> Login(LoginCommand command, CancellationToken cancellationToken)
     {
         var result = await sender.Send(command, cancellationToken);
-        return result.RequiresTwoFactor
-            ? StatusCode(StatusCodes.Status423Locked, new { type = "two_factor_required", detail = "Complete login with a TOTP code." })
-            : Ok(result);
+        if (result.RequiresTwoFactor)
+        {
+            return StatusCode(StatusCodes.Status423Locked, new { type = "two_factor_required", detail = "Complete login with a TOTP code." });
+        }
+
+        if (!string.IsNullOrWhiteSpace(result.RefreshToken))
+            AuthSessionCookies.Set(Response, result.RefreshToken, jwtOptions);
+
+        return Ok(result);
     }
 
     [HttpPost("refresh")]
     [AllowAnonymous]
-    public async Task<ActionResult<LoginResult>> Refresh(RefreshTokenCommand command, CancellationToken cancellationToken) =>
-        Ok(await sender.Send(command, cancellationToken));
+    public async Task<IActionResult> Refresh(
+        [FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] RefreshTokenCommand? command,
+        CancellationToken cancellationToken)
+    {
+        var refreshToken = !string.IsNullOrWhiteSpace(command?.RefreshToken)
+            ? command.RefreshToken
+            : AuthSessionCookies.ReadRefreshToken(Request);
+
+        if (string.IsNullOrWhiteSpace(refreshToken))
+        {
+            AuthSessionCookies.Clear(Response);
+            return Unauthorized();
+        }
+
+        try
+        {
+            var result = await sender.Send(new RefreshTokenCommand { RefreshToken = refreshToken }, cancellationToken);
+            if (!string.IsNullOrWhiteSpace(result.RefreshToken))
+                AuthSessionCookies.Set(Response, result.RefreshToken, jwtOptions);
+            return Ok(result);
+        }
+        catch (CustomException ex) when (ex.StatusCode is StatusCodes.Status400BadRequest
+            or StatusCodes.Status401Unauthorized
+            or StatusCodes.Status403Forbidden)
+        {
+            AuthSessionCookies.Clear(Response);
+            return StatusCode(ex.StatusCode, new ProblemDetails
+            {
+                Type = "https://inventoryx.app/problems/unauthorized",
+                Title = "Refresh token rejected.",
+                Status = ex.StatusCode,
+                Detail = ex.Message,
+            });
+        }
+    }
+
+    [HttpPost("logout")]
+    [AllowAnonymous]
+    public IActionResult Logout()
+    {
+        AuthSessionCookies.Clear(Response);
+        return Ok();
+    }
 
     [HttpPost("pin/exchange")]
     [LiveOnly("PIN exchange requires an authenticated device session and live credential verification.")]
@@ -44,14 +97,13 @@ public sealed class AuthController(ISender sender) : ApiControllerBase
         CancellationToken cancellationToken) =>
         Ok(await sender.Send(command, cancellationToken));
 
+    [HttpGet("google")]
     [HttpPost("google")]
     [AllowAnonymous]
     public IActionResult Google([FromQuery] string? returnUrl = null)
     {
-        var properties = new AuthenticationProperties
-        {
-            RedirectUri = string.IsNullOrWhiteSpace(returnUrl) ? "/" : returnUrl,
-        };
+        var properties = new AuthenticationProperties();
+        properties.Items["returnUrl"] = string.IsNullOrWhiteSpace(returnUrl) ? "/" : returnUrl;
         return Challenge(properties, GoogleDefaults.AuthenticationScheme);
     }
 

--- a/specs/001-inventory-pos-platform/contracts/auth-tenancy.md
+++ b/specs/001-inventory-pos-platform/contracts/auth-tenancy.md
@@ -4,10 +4,11 @@
 
 | Method | Path | Purpose | Notes |
 |--------|------|---------|-------|
-| POST | `/auth/register` `[anon]` | Create tenant + owner (FR-001) | Body: email, password, businessName, country, currency, businessType. Creates Trialing subscription (Professional, 14d). 201 → tenant summary + tokens |
-| POST | `/auth/login` `[anon]` | Email/password login | 200 → `{ accessToken, refreshToken, expiresIn }`; 401 on bad creds; 423 if 2FA required → complete via `/auth/2fa/verify` |
-| POST | `/auth/google` `[anon]` | Google OAuth code exchange | Existing flow retained |
-| POST | `/auth/refresh` `[anon]` | Rotate tokens | |
+| POST | `/auth/register` `[anon]` | Create tenant + owner (FR-001) | Body: email, password, businessName, country, currency, businessType. Creates Trialing subscription (Professional, 14d). 201 → tenant summary + tokens. Sets `inventoryx_refresh` (HttpOnly; Secure; SameSite=Lax; Path=/api/v1/auth) and readable `inventoryx_session=1` (same lifetime) |
+| POST | `/auth/login` `[anon]` | Email/password login | 200 → `{ accessToken, refreshToken, expiresIn }`; 401 on bad creds; 423 if 2FA required → complete via `/auth/2fa/verify`. Sets the same session cookies as register when tokens are issued |
+| GET/POST | `/auth/google` `[anon]` | Google OAuth challenge | Callback sets session cookies and redirects to `returnUrl` with `accessToken`, `refreshToken`, `accessTokenExpiresAt` query params |
+| POST | `/auth/refresh` `[anon]` | Rotate tokens | Body `{ refreshToken }` optional when the httpOnly refresh cookie is present. Rotates cookies on success; clears both cookies on 400/401/403. Cold loads without `inventoryx_session` stay anonymous by design (SPA skips this call) |
+| POST | `/auth/logout` `[anon]` | End SPA session cookies | Clears `inventoryx_refresh` and `inventoryx_session` |
 | POST | `/auth/2fa/enroll` / `verify` | TOTP setup & challenge (FR-006) | |
 | POST | `/auth/pin/exchange` | Register PIN → register-scoped token (FR-007) | Requires device token; body: userId, pin, registerId. 200 → short-lived scoped JWT |
 

--- a/tests/InventoryX.Presentation.Tests/Authentication/AuthSessionCookiesTests.cs
+++ b/tests/InventoryX.Presentation.Tests/Authentication/AuthSessionCookiesTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using InventoryX.Presentation.Authentication;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace InventoryX.Presentation.Tests.Authentication;
+
+public sealed class AuthSessionCookiesTests
+{
+    [Fact]
+    public void Set_writes_httpOnly_refresh_and_readable_session_marker()
+    {
+        var context = new DefaultHttpContext();
+
+        AuthSessionCookies.Set(context.Response, "refresh-secret", TimeSpan.FromDays(14));
+
+        var setCookie = context.Response.Headers.SetCookie.ToString();
+        setCookie.Should().Contain($"{AuthSessionCookies.RefreshTokenCookieName}=refresh-secret");
+        setCookie.Should().Contain("httponly", Exactly.Once());
+        setCookie.Should().Contain($"path={AuthSessionCookies.RefreshCookiePath}");
+        setCookie.Should().Contain($"{AuthSessionCookies.SessionMarkerCookieName}=1");
+        setCookie.Should().Contain("path=/");
+        setCookie.Should().Contain("secure");
+        setCookie.Should().Contain("samesite=lax");
+    }
+
+    [Fact]
+    public void Clear_expires_both_cookies_with_matching_paths()
+    {
+        var context = new DefaultHttpContext();
+        AuthSessionCookies.Set(context.Response, "refresh-secret", TimeSpan.FromDays(1));
+
+        AuthSessionCookies.Clear(context.Response);
+
+        var setCookie = context.Response.Headers.SetCookie.ToString();
+        setCookie.Should().Contain($"{AuthSessionCookies.RefreshTokenCookieName}=;");
+        setCookie.Should().Contain($"{AuthSessionCookies.SessionMarkerCookieName}=;");
+        setCookie.Should().Contain($"path={AuthSessionCookies.RefreshCookiePath}");
+        setCookie.Should().Contain("path=/");
+    }
+
+    [Fact]
+    public void ReadRefreshToken_returns_cookie_value_when_present()
+    {
+        var context = new DefaultHttpContext();
+        context.Request.Headers.Cookie = $"{AuthSessionCookies.RefreshTokenCookieName}=from-cookie";
+
+        AuthSessionCookies.ReadRefreshToken(context.Request).Should().Be("from-cookie");
+    }
+
+    [Fact]
+    public void ReadRefreshToken_returns_null_when_missing()
+    {
+        var context = new DefaultHttpContext();
+        AuthSessionCookies.ReadRefreshToken(context.Request).Should().BeNull();
+    }
+}

--- a/tests/InventoryX.Presentation.Tests/Scenarios/AuthSessionCookieTests.cs
+++ b/tests/InventoryX.Presentation.Tests/Scenarios/AuthSessionCookieTests.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using InventoryX.Presentation.Authentication;
+using Xunit;
+
+namespace InventoryX.Presentation.Tests.Scenarios;
+
+/// <summary>
+/// SPA session durability: httpOnly refresh cookie + readable inventoryx_session marker.
+/// </summary>
+public sealed class AuthSessionCookieTests : IAsyncLifetime
+{
+    private readonly TestAppFactory _factory = new();
+    private HttpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        await _factory.InitializeDatabaseAsync();
+        _client = _factory.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+        {
+            HandleCookies = false,
+            AllowAutoRedirect = false,
+        });
+    }
+
+    public Task DisposeAsync()
+    {
+        _factory.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private static IReadOnlyList<string> SetCookieHeaders(HttpResponseMessage response) =>
+        response.Headers.TryGetValues("Set-Cookie", out var values)
+            ? values.ToList()
+            : [];
+
+    [Fact]
+    public async Task Register_sets_refresh_and_session_marker_cookies()
+    {
+        var response = await _client.PostAsJsonAsync("/api/v1/auth/register", new
+        {
+            email = "cookie-owner@shop.gh",
+            password = "Password1!",
+            businessName = "Cookie Shop",
+            country = "GH",
+            currency = "GHS",
+            businessType = "Retail",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, await response.Content.ReadAsStringAsync());
+        var cookies = SetCookieHeaders(response);
+        cookies.Should().Contain(c =>
+            c.StartsWith($"{AuthSessionCookies.RefreshTokenCookieName}=", StringComparison.Ordinal) &&
+            c.Contains("httponly", StringComparison.OrdinalIgnoreCase) &&
+            c.Contains($"path={AuthSessionCookies.RefreshCookiePath}", StringComparison.OrdinalIgnoreCase));
+        cookies.Should().Contain(c =>
+            c.StartsWith($"{AuthSessionCookies.SessionMarkerCookieName}=1", StringComparison.Ordinal) &&
+            !c.Contains("httponly", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Refresh_without_body_uses_cookie_and_rotates_session_cookies()
+    {
+        var register = await _client.PostAsJsonAsync("/api/v1/auth/register", new
+        {
+            email = "refresh-cookie@shop.gh",
+            password = "Password1!",
+            businessName = "Refresh Shop",
+            country = "GH",
+            currency = "GHS",
+            businessType = "Retail",
+        });
+        register.StatusCode.Should().Be(HttpStatusCode.Created, await register.Content.ReadAsStringAsync());
+        var registration = JsonDocument.Parse(await register.Content.ReadAsStringAsync()).RootElement;
+        var refreshToken = registration.GetProperty("refreshToken").GetString();
+        refreshToken.Should().NotBeNullOrEmpty();
+
+        using var refreshRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/refresh");
+        refreshRequest.Headers.Add("Cookie", $"{AuthSessionCookies.RefreshTokenCookieName}={refreshToken}");
+        var refresh = await _client.SendAsync(refreshRequest);
+
+        refresh.StatusCode.Should().Be(HttpStatusCode.OK, await refresh.Content.ReadAsStringAsync());
+        var body = JsonDocument.Parse(await refresh.Content.ReadAsStringAsync()).RootElement;
+        body.GetProperty("accessToken").GetString().Should().NotBeNullOrEmpty();
+        body.GetProperty("refreshToken").GetString().Should().NotBe(refreshToken);
+
+        var cookies = SetCookieHeaders(refresh);
+        cookies.Should().Contain(c => c.StartsWith($"{AuthSessionCookies.RefreshTokenCookieName}=", StringComparison.Ordinal));
+        cookies.Should().Contain(c => c.StartsWith($"{AuthSessionCookies.SessionMarkerCookieName}=1", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Refresh_with_invalid_cookie_clears_session_cookies()
+    {
+        using var refreshRequest = new HttpRequestMessage(HttpMethod.Post, "/api/v1/auth/refresh");
+        refreshRequest.Headers.Add("Cookie", $"{AuthSessionCookies.RefreshTokenCookieName}=not-a-real-token");
+        var refresh = await _client.SendAsync(refreshRequest);
+
+        refresh.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        var cookies = SetCookieHeaders(refresh);
+        cookies.Should().Contain(c =>
+            c.StartsWith($"{AuthSessionCookies.RefreshTokenCookieName}=", StringComparison.Ordinal) &&
+            (c.Contains("expires=", StringComparison.OrdinalIgnoreCase) || c.Contains("max-age=0", StringComparison.OrdinalIgnoreCase)));
+        cookies.Should().Contain(c =>
+            c.StartsWith($"{AuthSessionCookies.SessionMarkerCookieName}=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Logout_clears_session_cookies()
+    {
+        var response = await _client.PostAsync("/api/v1/auth/logout", null);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var cookies = SetCookieHeaders(response);
+        cookies.Should().Contain(c => c.StartsWith($"{AuthSessionCookies.RefreshTokenCookieName}=", StringComparison.Ordinal));
+        cookies.Should().Contain(c => c.StartsWith($"{AuthSessionCookies.SessionMarkerCookieName}=", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Refresh_without_cookie_or_body_stays_unauthorized_and_clears_markers()
+    {
+        var response = await _client.PostAsync("/api/v1/auth/refresh", null);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+        SetCookieHeaders(response).Should().NotBeEmpty();
+    }
+}

--- a/tests/InventoryX.Presentation.Tests/Swagger/ContractSurfaceTests.cs
+++ b/tests/InventoryX.Presentation.Tests/Swagger/ContractSurfaceTests.cs
@@ -36,6 +36,7 @@ public sealed class ContractSurfaceTests
     private static readonly (string Method, string Path)[] Expected =
     [
         ("post", "/auth/register"), ("post", "/auth/login"), ("post", "/auth/google"),
+        ("post", "/auth/refresh"), ("post", "/auth/logout"),
         ("get", "/tenant"), ("patch", "/tenant"), ("post", "/tenant/export"), ("get", "/tenant/export/{jobId}"),
         ("get", "/users"), ("post", "/users/invitations"), ("post", "/users/invitations/{id}/accept"), ("patch", "/users/{id}"),
         ("get", "/roles"), ("get", "/audit-log"), ("get", "/billing/plans"), ("get", "/billing/subscription"),


### PR DESCRIPTION
## Summary
- Delivers the Cycle 1 inventory POS platform on `feat/001-inventory-pos-platform` (tenancy, auth, catalogue, sales, reports, billing, offline sync, and related contracts).
- Adds SPA session durability: httpOnly `inventoryx_refresh` + readable `inventoryx_session` cookies on register/login/OAuth, cookie-based `/auth/refresh` with rotation/revocation, and `/auth/logout` cookie clear.
- Updates auth-tenancy contract surface and adds unit + scenario coverage for session cookies.

## Test plan
- [ ] `dotnet test InventoryX.sln --configuration Release`
- [ ] Register/login set `inventoryx_refresh` (HttpOnly, Path=/api/v1/auth) and `inventoryx_session=1`
- [ ] `POST /api/v1/auth/refresh` with only the refresh cookie rotates tokens and cookies
- [ ] Invalid/missing refresh clears cookies and returns 401
- [ ] `POST /api/v1/auth/logout` clears both cookies
- [ ] Google OAuth callback sets cookies and redirects with access/refresh query params

